### PR TITLE
Vagrantのfirewalldの有効化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 .rbenv-gemsets
 /public/uploads
 .vagrant
+.vagrant/machines/default/virtualbox/*
+/provision/ssh_key/*

--- a/provision/roles/deploy_user/tasks/main.yml
+++ b/provision/roles/deploy_user/tasks/main.yml
@@ -14,7 +14,7 @@
   user: name={{ user }} state=present group={{ group }} shell=/bin/bash
 
 - name: copy ssh
-  template: src=/vagrant/id_rsa.pub dest=/home/ops/id_rsa.pub
+  template: src=/vagrant/provision/ssh_key/id_rsa.pub dest=/home/ops/id_rsa.pub
   
 - name: Create .ssh
   shell: mkdir /home/ops/.ssh; chmod 700 /home/ops/.ssh
@@ -24,6 +24,3 @@
 
 - name: change owner & group
   shell: chown -R ops /home/ops/.ssh; chgrp -R ops /home/ops/.ssh
-
-# - name: SSH setting
-#   authorized_key: user={{ user }} key="{{ lookup('file', '/home/ops/id_rsa.pub') }}" manage_dir=yes path='/home/ops'

--- a/provision/roles/firewalld/tasks/main.yml
+++ b/provision/roles/firewalld/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: enable firewall
+  shell: systemctl enable firewalld; systemctl start firewalld
+  tags: firewall
+- name: check default zone name
+  shell: firewall-cmd --get-default-zone
+  tags: firewall
+- name: allow http
+  shell: firewall-cmd --add-service=http --zone=public --permanent
+  tags: firewall
+- name: allow https
+  shell: firewall-cmd --add-service=https --zone=public --permanent
+  tags: firewall
+- name: reload to be able to apply firewall setting
+  shell: firewall-cmd --reload
+  tags: firewall
+

--- a/provision/vagrant.yml
+++ b/provision/vagrant.yml
@@ -16,4 +16,4 @@
     - common
     - mysql
     - deploy_user
-    # - iptables
+    - firewalld

--- a/provision/vagrant.yml
+++ b/provision/vagrant.yml
@@ -8,8 +8,12 @@
     rbenv_root: /home/vagrant/.rbenv
     rbenv_bin: /home/vagrant/.rbenv/libexec/rbenv
     group: ops
+    # NOTE: Password must be hashed. this is created with:
+    # openssl passwd -salt salty -1 あなたのパスワード
+    user_password: $1$salty$9LqYQSloA.dNYnW6izxVe/
     user: ops
   roles:
     - common
     - mysql
     - deploy_user
+    # - iptables


### PR DESCRIPTION
## このPRについて

issue #9 の対応。
CentOS7からは、iptabelsよりもfirewalldの方がデフォルトのようなのでそちらを利用