### PR TITLE
記事の子要素の表示箇所のリファクタリング

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,0 +1,20 @@
+module ArticlesHelper
+  def article_element_data(tag_type, contents)
+    if(tag_type == 'img')
+      picture = Picture.find(contents)
+      image_tag picture.image.url, class: 'img-responsive'
+    else
+      elements = {
+        sub_head: {
+          actual_tag: :h3,
+          raw_data: contents
+        },
+        description: {
+          actual_tag: :p,
+          raw_data: contents
+        }
+      }
+      content_tag(elements[tag_type.to_sym][:actual_tag], elements[tag_type.to_sym][:raw_data])
+    end
+  end
+end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -10,21 +10,8 @@
           </header>
           <div class="lwb__article__contents__body">
             <% @article.elements.each do |element| %>
-              <% if(element[:tag_name] == 'sub_head') %>
-                <h3>
-                  <%= element[:element_data] %>
-                </h3>
-              <% elsif(element[:tag_name] == 'description') %>
-                <p>
-                  <%= element[:element_data] %>
-                </p>
-              <% elsif(element[:tag_name] == 'img') %>
-                <% picture = Picture.find(element[:element_data]) %>
-                <%= image_tag picture.image.url, class: 'img-responsive' %>
-              <% elsif(element[:tag_name] == 'instagram') %>
-                <blockquote class="instagram-media" data-instgrm-captioned data-instgrm-version="5"><a href="<%= element[:element_data] %>" target="_blank"></a></blockquote>
-              <% end %>
-            <% end %>
+              <%= article_element_data(element[:tag_name], element[:element_data]) %>
+          <% end %>
           </div>
         </article>
         <%= link_to '戻る', root_path, class: 'btn btn-default' %>

--- a/spec/helpers/articles_helper_spec.rb
+++ b/spec/helpers/articles_helper_spec.rb
@@ -13,8 +13,9 @@ describe ArticlesHelper, type: :helper do
     context 'imgが引数に渡された場合' do
       let(:picture){ create(:picture)}
       it 'imgタグが含まれるHTMLを生成する' do
-        expect(helper.article_element_data('img', picture.id)).to eq "<img class=\"img-responsive\" src=\"/uploads/picture/image/#{picture.id}/sample.jpg\" alt=\"Sample\" />"
+        expected = "<img class=\"img-responsive\" src=\"/uploads/picture/image/#{picture.id}/sample.jpg\" alt=\"Sample\" />"
+        expect(helper.article_element_data('img', picture.id)).to eq expected
       end
-    end    
+    end
   end
 end

--- a/spec/helpers/articles_helper_spec.rb
+++ b/spec/helpers/articles_helper_spec.rb
@@ -1,0 +1,20 @@
+describe ArticlesHelper, type: :helper do
+  describe 'article_element_dataについて' do
+    context 'sub_headが引数に渡された場合' do
+      it 'H3タグが含まれるHTMLを生成する' do
+        expect(helper.article_element_data('sub_head', 'text')).to eq '<h3>text</h3>'
+      end
+    end
+    context 'descriptionが引数に渡された場合' do
+      it 'Pタグが含まれるHTMLを生成する' do
+        expect(helper.article_element_data('description', 'text')).to eq '<p>text</p>'
+      end
+    end
+    context 'imgが引数に渡された場合' do
+      let(:picture){ create(:picture)}
+      it 'imgタグが含まれるHTMLを生成する' do
+        expect(helper.article_element_data('img', picture.id)).to eq "<img class=\"img-responsive\" src=\"/uploads/picture/image/#{picture.id}/sample.jpg\" alt=\"Sample\" />"
+      end
+    end    
+  end
+end


### PR DESCRIPTION
## このPRについて

issue #82 の対応

Viewにはロジックを入れないようにするためにarticle_element_dataというヘルパーメソッドを実装

![2016-04-22 16 16 29](https://cloud.githubusercontent.com/assets/950924/14734478/9c720dc6-08a5-11e6-81bb-8a4604c28dea.png)


```sh
ArticlesHelper
  article_element_dataについて
    imgが引数に渡された場合
      imgタグが含まれるHTMLを生成する
    descriptionが引数に渡された場合
      Pタグが含まれるHTMLを生成する
    sub_headが引数に渡された場合
      H3タグが含まれるHTMLを生成する
```