### PR TITLE
[Fixed] RailsEngine側で記事データを管理できるようにする

### DIFF
--- a/blog_engine/app/assets/javascripts/blog_engine/application.js
+++ b/blog_engine/app/assets/javascripts/blog_engine/application.js
@@ -10,4 +10,6 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
+//= require jquery_ujs
 //= require_tree .

--- a/blog_engine/app/assets/javascripts/blog_engine/articles.js
+++ b/blog_engine/app/assets/javascripts/blog_engine/articles.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/blog_engine/app/assets/stylesheets/blog_engine/articles.css
+++ b/blog_engine/app/assets/stylesheets/blog_engine/articles.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/blog_engine/app/assets/stylesheets/scaffold.css
+++ b/blog_engine/app/assets/stylesheets/scaffold.css
@@ -1,0 +1,56 @@
+body { background-color: #fff; color: #333; }
+
+body, p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size:   13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a { color: #000; }
+a:visited { color: #666; }
+a:hover { color: #fff; background-color:#000; }
+
+div.field, div.actions {
+  margin-bottom: 10px;
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px;
+  padding-bottom: 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+}
+
+#error_explanation h2 {
+  text-align: left;
+  font-weight: bold;
+  padding: 5px 5px 5px 15px;
+  font-size: 12px;
+  margin: -7px;
+  margin-bottom: 0px;
+  background-color: #c00;
+  color: #fff;
+}
+
+#error_explanation ul li {
+  font-size: 12px;
+  list-style: square;
+}

--- a/blog_engine/app/controllers/blog_engine/articles_controller.rb
+++ b/blog_engine/app/controllers/blog_engine/articles_controller.rb
@@ -1,0 +1,53 @@
+require_dependency "blog_engine/application_controller"
+
+module BlogEngine
+  class ArticlesController < ApplicationController
+    before_action :set_article, only: [:show, :edit, :update, :destroy]
+
+    def index
+      @articles = Article.all
+    end
+
+    def show
+    end
+
+    def new
+      @article = Article.new
+    end
+
+    def edit
+    end
+
+    def create
+      @article = Article.new(article_params)
+
+      if @article.save
+        redirect_to @article, notice: 'Article was successfully created.'
+      else
+        render :new
+      end
+    end
+
+    def update
+      if @article.update(article_params)
+        redirect_to @article, notice: 'Article was successfully updated.'
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @article.destroy
+      redirect_to articles_url, notice: 'Article was successfully destroyed.'
+    end
+
+    private
+      def set_article
+        @article = Article.find(params[:id])
+      end
+
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
+  end
+end

--- a/blog_engine/app/helpers/blog_engine/articles_helper.rb
+++ b/blog_engine/app/helpers/blog_engine/articles_helper.rb
@@ -1,0 +1,4 @@
+module BlogEngine
+  module ArticlesHelper
+  end
+end

--- a/blog_engine/app/models/blog_engine/article.rb
+++ b/blog_engine/app/models/blog_engine/article.rb
@@ -1,0 +1,4 @@
+module BlogEngine
+  class Article < ActiveRecord::Base
+  end
+end

--- a/blog_engine/app/views/blog_engine/articles/_form.html.erb
+++ b/blog_engine/app/views/blog_engine/articles/_form.html.erb
@@ -1,0 +1,25 @@
+<%= form_for(@article) do |f| %>
+  <% if @article.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@article.errors.count, "error") %> prohibited this article from being saved:</h2>
+
+      <ul>
+      <% @article.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :title %><br>
+    <%= f.text_field :title %>
+  </div>
+  <div class="field">
+    <%= f.label :body %><br>
+    <%= f.text_area :body %>
+  </div>
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/blog_engine/app/views/blog_engine/articles/edit.html.erb
+++ b/blog_engine/app/views/blog_engine/articles/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Article</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Show', @article %> |
+<%= link_to 'Back', articles_path %>

--- a/blog_engine/app/views/blog_engine/articles/index.html.erb
+++ b/blog_engine/app/views/blog_engine/articles/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Listing Articles</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Body</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @articles.each do |article| %>
+      <tr>
+        <td><%= article.title %></td>
+        <td><%= article.body %></td>
+        <td><%= link_to 'Show', article %></td>
+        <td><%= link_to 'Edit', edit_article_path(article) %></td>
+        <td><%= link_to 'Destroy', article, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Article', new_article_path %>

--- a/blog_engine/app/views/blog_engine/articles/new.html.erb
+++ b/blog_engine/app/views/blog_engine/articles/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Article</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Back', articles_path %>

--- a/blog_engine/app/views/blog_engine/articles/show.html.erb
+++ b/blog_engine/app/views/blog_engine/articles/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @article.title %>
+</p>
+
+<p>
+  <strong>Body:</strong>
+  <%= @article.body %>
+</p>
+
+<%= link_to 'Edit', edit_article_path(@article) %> |
+<%= link_to 'Back', articles_path %>

--- a/blog_engine/config/routes.rb
+++ b/blog_engine/config/routes.rb
@@ -1,2 +1,3 @@
 BlogEngine::Engine.routes.draw do
+  resources :articles
 end

--- a/blog_engine/db/migrate/20170714023455_create_blog_engine_articles.rb
+++ b/blog_engine/db/migrate/20170714023455_create_blog_engine_articles.rb
@@ -1,0 +1,10 @@
+class CreateBlogEngineArticles < ActiveRecord::Migration
+  def change
+    create_table :blog_engine_articles do |t|
+      t.string :title
+      t.text :body
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/blog_engine/test/controllers/blog_engine/articles_controller_test.rb
+++ b/blog_engine/test/controllers/blog_engine/articles_controller_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+module BlogEngine
+  class ArticlesControllerTest < ActionController::TestCase
+    setup do
+      @article = blog_engine_articles(:one)
+      @routes = Engine.routes
+    end
+
+    test "should get index" do
+      get :index
+      assert_response :success
+      assert_not_nil assigns(:articles)
+    end
+
+    test "should get new" do
+      get :new
+      assert_response :success
+    end
+
+    test "should create article" do
+      assert_difference('Article.count') do
+        post :create, article: { body: @article.body, title: @article.title }
+      end
+
+      assert_redirected_to article_path(assigns(:article))
+    end
+
+    test "should show article" do
+      get :show, id: @article
+      assert_response :success
+    end
+
+    test "should get edit" do
+      get :edit, id: @article
+      assert_response :success
+    end
+
+    test "should update article" do
+      patch :update, id: @article, article: { body: @article.body, title: @article.title }
+      assert_redirected_to article_path(assigns(:article))
+    end
+
+    test "should destroy article" do
+      assert_difference('Article.count', -1) do
+        delete :destroy, id: @article
+      end
+
+      assert_redirected_to articles_path
+    end
+  end
+end

--- a/blog_engine/test/fixtures/blog_engine/articles.yml
+++ b/blog_engine/test/fixtures/blog_engine/articles.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  body: MyText
+
+two:
+  title: MyString
+  body: MyText

--- a/blog_engine/test/models/blog_engine/article_test.rb
+++ b/blog_engine/test/models/blog_engine/article_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+module BlogEngine
+  class ArticleTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end

--- a/db/migrate/20170714034523_create_blog_engine_articles.blog_engine.rb
+++ b/db/migrate/20170714034523_create_blog_engine_articles.blog_engine.rb
@@ -1,0 +1,11 @@
+# This migration comes from blog_engine (originally 20170714023455)
+class CreateBlogEngineArticles < ActiveRecord::Migration
+  def change
+    create_table :blog_engine_articles do |t|
+      t.string :title
+      t.text :body
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160520064359) do
+ActiveRecord::Schema.define(version: 20170714034523) do
 
   create_table "areas", force: :cascade do |t|
     t.string   "name",                limit: 255
@@ -74,6 +74,13 @@ ActiveRecord::Schema.define(version: 20160520064359) do
   end
 
   add_index "beer_styles", ["name"], name: "index_beer_styles_on_name", using: :btree
+
+  create_table "blog_engine_articles", force: :cascade do |t|
+    t.string   "title",      limit: 255
+    t.text     "body",       limit: 65535
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
 
   create_table "breweries", force: :cascade do |t|
     t.string   "name",       limit: 255, null: false


### PR DESCRIPTION
## このPRについて
#157 の実装
`blog_engine`配下に記事データを管理できるMVCを作成する


## 作業完了条件について

- [x] ArticleというModel名＋関連するController・Viewを実装する
  - scaffoldで生成されるのをそのまま利用してください
  - Articleには、title:string、body:text の２つのカラムを持った構造にしてください
- [x] 上記実装して、Rails Consoleなどから記事データを適当に作ってもらうとlocalhost:3000/blog/articles で記事の一覧が表示されるようになるはずなのでその画面キャプチャ添えてください

![2017-07-14 13 23 20](https://user-images.githubusercontent.com/12405287/28198451-40e585fa-6899-11e7-9c43-404286b8e153.png)

