### PR TITLE
[Fixed] Rails Engine側でFactoryGirlが使えるように設定する

### DIFF
--- a/blog_engine/.gitignore
+++ b/blog_engine/.gitignore
@@ -1,8 +1,9 @@
 .bundle/
 log/*.log
 pkg/
-test/dummy/db/*.sqlite3
-test/dummy/db/*.sqlite3-journal
-test/dummy/log/*.log
-test/dummy/tmp/
-test/dummy/.sass-cache
+spec/dummy_app/db/*.sqlite3
+spec/dummy_app/db/*.sqlite3-journal
+spec/dummy_app/db/schema.rb
+spec/dummy_app/log/*.log
+spec/dummy_app/tmp/
+spec/dummy_app/.sass-cache

--- a/blog_engine/Gemfile
+++ b/blog_engine/Gemfile
@@ -1,14 +1,8 @@
 source 'https://rubygems.org'
-
-# Declare your gem's dependencies in blog_engine.gemspec.
-# Bundler will treat runtime dependencies like base dependencies, and
-# development dependencies will be added by default to the :development group.
 gemspec
-
-# Declare any dependencies that are still in development here instead of in
-# your gemspec. These might include edge Rails or gems from your path or
-# Git. Remember to move these dependencies to your gemspec before releasing
-# your gem to rubygems.org.
-
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
+group :development, :test do
+  gem 'pry-rails'
+  gem 'rb-readline'
+end

--- a/blog_engine/Gemfile.lock
+++ b/blog_engine/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.4)
     builder (3.2.3)
+    coderay (1.1.1)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     erubis (2.7.0)
@@ -58,6 +59,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -65,6 +67,12 @@ GEM
     minitest (5.10.2)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.5)
+      pry (>= 0.9.10)
     rack (1.6.8)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -93,6 +101,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
+    rb-readline (0.5.4)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -110,6 +119,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    slop (3.6.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -129,6 +139,8 @@ PLATFORMS
 DEPENDENCIES
   blog_engine!
   factory_girl_rails
+  pry-rails
+  rb-readline
   rspec-rails
   sqlite3
 

--- a/blog_engine/Rakefile
+++ b/blog_engine/Rakefile
@@ -4,34 +4,33 @@ rescue LoadError
   puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
 end
 
-require 'rdoc/task'
-
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'BlogEngine'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
-end
-
-APP_RAKEFILE = File.expand_path("../test/dummy/Rakefile", __FILE__)
-load 'rails/tasks/engine.rake'
-
-
-load 'rails/tasks/statistics.rake'
-
-
-
 Bundler::GemHelper.install_tasks
 
-require 'rake/testtask'
+APP_RAKEFILE = File.expand_path("../spec/dummy_app/Rakefile", __FILE__)
+load 'rails/tasks/engine.rake'
+#load 'rails/tasks/statistics.rake'
+require "rspec/core/rake_task"
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << 'lib'
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
-  t.verbose = false
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.pattern = 'spec/**/*_spec.rb'
+  # spec.rspec_opts = ['-cfs --backtrace']
 end
 
-
 task default: :test
+
+#require 'rdoc/task'
+#RDoc::Task.new(:rdoc) do |rdoc|
+#  rdoc.rdoc_dir = 'rdoc'
+#  rdoc.title    = 'BlogEngine'
+#  rdoc.options << '--line-numbers'
+#  rdoc.rdoc_files.include('README.rdoc')
+#  rdoc.rdoc_files.include('lib/**/*.rb')
+#end
+
+#require 'rake/testtask'
+#Rake::TestTask.new(:test) do |t|
+#  t.libs << 'lib'
+#  t.libs << 'test'
+#  t.pattern = 'test/**/*_test.rb'
+#  t.verbose = false
+#end

--- a/blog_engine/blog_engine.gemspec
+++ b/blog_engine/blog_engine.gemspec
@@ -14,8 +14,7 @@ Gem::Specification.new do |s|
   s.description = "lifeisbeer: Description of BlogEngine."
   s.license     = "MIT"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
-  #s.test_files = Dir["test/**/*"]
+  s.files = Dir["{app,config,db,lib}/**/*", "spec/factories/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", "~> 4.2.0"

--- a/blog_engine/lib/blog_engine/engine.rb
+++ b/blog_engine/lib/blog_engine/engine.rb
@@ -1,6 +1,10 @@
 module BlogEngine
   class Engine < ::Rails::Engine
     isolate_namespace BlogEngine
+    
+    initializer "model_core.factories", :after => "factory_girl.set_factory_paths" do
+      FactoryGirl.definition_file_paths << File.expand_path('../../../spec/factories', __FILE__) if defined?(FactoryGirl)
+    end
 
     config.generators do |g|
       g.test_framework :rspec, fixture: false

--- a/blog_engine/spec/controllers/articles_controller_spec.rb
+++ b/blog_engine/spec/controllers/articles_controller_spec.rb
@@ -3,7 +3,7 @@ describe BlogEngine::ArticlesController, type: :controller do
   describe "GET /articles" do
     it "works! (now write some real specs)" do
       get :index
-      FactoryGirl.create(:blog_engine_article)
+      create(:blog_engine_article)
       expect(response).to have_http_status(200)
     end
   end

--- a/blog_engine/spec/controllers/articles_controller_spec.rb
+++ b/blog_engine/spec/controllers/articles_controller_spec.rb
@@ -3,6 +3,7 @@ describe BlogEngine::ArticlesController, type: :controller do
   describe "GET /articles" do
     it "works! (now write some real specs)" do
       get :index
+      FactoryGirl.create(:blog_engine_article)
       expect(response).to have_http_status(200)
     end
   end

--- a/blog_engine/spec/factories/blog_engine_articles.rb
+++ b/blog_engine/spec/factories/blog_engine_articles.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :article do
+  factory :blog_engine_article, class: BlogEngine::Article do
     sequence(:title) { |n| "記事のタイトル#{n}" }
     body "Boddddddy"
   end

--- a/blog_engine/spec/rails_helper.rb
+++ b/blog_engine/spec/rails_helper.rb
@@ -11,7 +11,7 @@ require 'factory_girl_rails'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  #config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!

--- a/blog_engine/spec/spec_helper.rb
+++ b/blog_engine/spec/spec_helper.rb
@@ -2,6 +2,7 @@ ENV['RAILS_ENV'] ||= 'test'
 
 require File.expand_path("../dummy_app/config/environment.rb", __FILE__)
 require 'rspec/rails'
+require 'factory_girl_rails'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -13,4 +14,5 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.include FactoryGirl::Syntax::Methods
 end


### PR DESCRIPTION
## このPRについて
（#163 の実装）
- [x] Rails Engine側でFactoryGirlが使えるように設定を行う
- [x] サンプルのspecを作成して検証

## テストDBの作成、specの実行手順
```
$ cd blog_engine
$ RAILS_ENV=test rake db:create
$ RAILS_ENV=test rake db:migrate
$ bundle exec rspec spec/controllers/
```
## テスト実行結果
![2017-07-25 10 38 55](https://user-images.githubusercontent.com/12405287/28551852-839d6b1c-7125-11e7-9051-34ff02f9fcef.png)

## その他
- 上記のmigrationを実行すると `blog_engine/spec/dummy_app/db/schema.rb`が作られてしまい、これをgit管理するべきなのか。 => git管理に入れない
- dummy_appのDBもsqlite3からmysqlに変更した方が良いのかどうか => 別issueで対応
