### PR TITLE
[Fixed] フォーム要素が動的に表示されるUI実装

### DIFF
--- a/blog_engine/app/assets/javascripts/blog_engine/application.js
+++ b/blog_engine/app/assets/javascripts/blog_engine/application.js
@@ -15,3 +15,4 @@
 //= require blog_engine/tether.min
 //= require blog_engine/bootstrap.min
 //= require blog_engine/vue
+//= require blog_engine/articles

--- a/blog_engine/app/assets/javascripts/blog_engine/articles.js
+++ b/blog_engine/app/assets/javascripts/blog_engine/articles.js
@@ -1,2 +1,8 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.
+window.onload = function() {
+  var articleViewModel = new Vue({
+    el: '#article-form',
+    data: {
+      show: false
+    }
+  })
+}

--- a/blog_engine/app/views/blog_engine/articles/index.html.erb
+++ b/blog_engine/app/views/blog_engine/articles/index.html.erb
@@ -24,19 +24,19 @@
   </table>
 
   <div id="article-form">
-    <button @click="show=!show" class="btn btn-info">登録フォーム表示</button>
+    <button @click="show=!show" class="btn btn-info">NewArticle</button>
     <br><br>
     <div v-show="show">
       <div>
-        <label for="title">タイトル</label>
+        <label for="title">Title</label>
         <input type="text" id="title" />
       </div>
       <div>
-        <label for="body">内容</label>
+        <label for="body">Body</label>
         <textarea id="body"></textarea>
       </div>
       <div>
-        <button class="btn btn-primary">登録</button>
+        <button class="btn btn-primary">Submit</button>
       </div>
     </div>
   </div>

--- a/blog_engine/app/views/blog_engine/articles/index.html.erb
+++ b/blog_engine/app/views/blog_engine/articles/index.html.erb
@@ -23,18 +23,22 @@
     </tbody>
   </table>
 
-  <%= link_to 'New Article', new_article_path, class: "btn btn-info" %>
-  <br><br>
-  <!-- bootstrap javascript sample -->
-  <div class="dropdown">
-    <button id="dLabel" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      Dropdown sample
-      <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu" aria-labelledby="dLabel">
-      <li>Menu A</li>
-      <li>Menu B</li>
-      <li>Menu C</li>
-    </ul>
+  <div id="article-form">
+    <button @click="show=!show" class="btn btn-info">登録フォーム表示</button>
+    <br><br>
+    <div v-show="show">
+      <div>
+        <label for="title">タイトル</label>
+        <input type="text" id="title" />
+      </div>
+      <div>
+        <label for="body">内容</label>
+        <textarea id="body"></textarea>
+      </div>
+      <div>
+        <button class="btn btn-primary">登録</button>
+      </div>
+    </div>
   </div>
+
 </div>


### PR DESCRIPTION
## このPRについて
ブログ一覧ページでボタンを押すとページ内に登録フォームを表示するように実装しました。
関連Issueは #169 

## WIPが外れる条件
- ブログ一覧（/blog/articles）にアクセスした時にNewArticlesのボタンが表示されてるはずなのでそれをクリック
- クリックしたら、画面遷移しないで、そのまま入力用のフォームが表示される

## 実装した画面
![github](https://user-images.githubusercontent.com/12405287/29054861-bf67762e-7c33-11e7-9cba-3d3d8c9b692f.gif)
