### PR TITLE
[Fixed] 動的に表示されるフォームを通じて記事が登録できる

### DIFF
--- a/blog_engine/app/assets/javascripts/blog_engine/articles.js
+++ b/blog_engine/app/assets/javascripts/blog_engine/articles.js
@@ -21,12 +21,13 @@ window.onload = function() {
           url: baseURL,
           method: 'POST',
           data: { title: that.title, body: that.body }
-        }
+        };
         $.ajax(params).done(function(response){
           that.message = '送信完了しました';
           that.show = false;
+          that.title = that.body = '';
         });
       }
     }
-  })
-}
+  });
+};

--- a/blog_engine/app/controllers/blog_engine/articles_controller.rb
+++ b/blog_engine/app/controllers/blog_engine/articles_controller.rb
@@ -19,16 +19,12 @@ module BlogEngine
     end
 
     def create
-      render json: { success: true }
-=begin
-      @article = Article.new(article_params)
-
+      @article = Article.new(title: params[:title], body: params[:body])
       if @article.save
         redirect_to @article, notice: 'Article was successfully created.'
       else
         render :new
       end
-=end
     end
 
     def update


### PR DESCRIPTION
## このPRについて
新規登録フォームの入力値をDBへ登録できるように実装しました。
関連Issueは #171 

## WIPが外れる条件
- [x] 表示されるフォームで必要情報が入力されたら記事が登録できる
  - 最終的には画面遷移しない形を目指したいと思ってますが、今回のIssueでそこまで含めると大変かもしれないので、登録→完了の画面遷移してもOKです

## 実装した画面
![github](https://user-images.githubusercontent.com/12405287/29152018-c6a3ba14-7dbf-11e7-8628-7b383f8f0b5a.gif)
