### PR TITLE
[Fixed] 記事の新規作成後ページを再読み込みせずに一覧に反映する

### DIFF
--- a/blog_engine/app/assets/javascripts/blog_engine/application.js
+++ b/blog_engine/app/assets/javascripts/blog_engine/application.js
@@ -15,4 +15,5 @@
 //= require blog_engine/tether.min
 //= require blog_engine/bootstrap.min
 //= require blog_engine/vue
+//= require blog_engine/models/articleModel
 //= require blog_engine/articles

--- a/blog_engine/app/assets/javascripts/blog_engine/articles.js
+++ b/blog_engine/app/assets/javascripts/blog_engine/articles.js
@@ -1,51 +1,35 @@
 window.onload = function() {
-  var articlesListViewModel = new Vue({
-    el: '#articles-list',
+  var articleModel = new ArticleModel();
+  var articlesView = new Vue({
+    el: '#articles-view',
     data: {
-      articles: []
-    },
-    beforeMount: function () {
-      var that = this,
-          hostname = window.location.hostname,
-          protocol = window.location.protocol,
-          port =  window.location.port,
-          baseURL = [protocol,'//', hostname,':', port, '/blog/articles.json'].join('');
-
-      var params = {
-        url: baseURL,
-        method: 'GET'
-      };
-      $.ajax(params).done(function(response){
-        that.articles = response.articles;
-      });
-    }
-  });
-
-  var articleViewModel = new Vue({
-    el: '#article-form',
-    data: {
+      articles: [],
       show: false,
       loading: false,
       message: '送信中です',
       title: '',
       body: ''
     },
+    beforeMount: function () {
+      var that = this;
+      articleModel.index();
+      articleModel.deferred.done(function(response) {
+        that.articles = response.articles;
+      });
+    },
     methods: {
       create: function () {
         this.loading = !this.loading;
         var that = this,
-            hostname = window.location.hostname,
-            protocol = window.location.protocol,
-            port =  window.location.port,
-            baseURL = [protocol,'//', hostname,':', port, '/blog/articles'].join('');
-
-        var params = {
-          url: baseURL,
-          method: 'POST',
-          data: { title: that.title, body: that.body }
-        };
-        $.ajax(params).done(function(response){
-          that.message = '送信完了しました';
+            data = { title: that.title, body: that.body };
+        articleModel.create(data);
+        articleModel.deferred.done(function(response) {
+          if (that.title === response.title && that.body === response.body){
+            that.message = '登録しました';
+            that.articles.push({ id: response.id, title: response.title, body: response.body });
+          } else {
+            that.message = '正しく登録できませんでした';
+          }
           that.show = false;
           that.title = '';
           that.body = '';

--- a/blog_engine/app/assets/javascripts/blog_engine/articles.js
+++ b/blog_engine/app/assets/javascripts/blog_engine/articles.js
@@ -37,4 +37,9 @@ window.onload = function() {
       }
     }
   });
+
+  articlesView.$on('updatedArticles', function () {
+    this.updateArticles();
+  });
+
 };

--- a/blog_engine/app/assets/javascripts/blog_engine/articles.js
+++ b/blog_engine/app/assets/javascripts/blog_engine/articles.js
@@ -37,9 +37,4 @@ window.onload = function() {
       }
     }
   });
-
-  articlesView.$on('updatedArticles', function () {
-    this.updateArticles();
-  });
-
 };

--- a/blog_engine/app/assets/javascripts/blog_engine/models/articleModel.js
+++ b/blog_engine/app/assets/javascripts/blog_engine/models/articleModel.js
@@ -1,0 +1,32 @@
+var ArticleModel = (function () {
+  function ArticleModel() {
+    var hostname = window.location.hostname,
+        protocol = window.location.protocol,
+        port = window.location.port;
+    this.baseURL = [protocol, '//', hostname, ':', port, '/blog'].join('');
+  }
+
+  ArticleModel.prototype = {
+    index : function () {
+      var params = {
+          url: this.baseURL + '/articles.json',
+          type: "GET",
+          action: "index"
+      };
+      return this._request(params);
+    },
+    create : function (data) {
+      var params = {
+          url: this.baseURL + '/articles',
+          type: "POST",
+          data: { title: data['title'], body: data['body'] },
+          action: "create"
+      };
+      return this._request(params);
+    },
+    _request : function (params) {
+      this.deferred = $.ajax(params);
+    }
+  };
+  return ArticleModel;
+}());

--- a/blog_engine/app/controllers/blog_engine/articles_controller.rb
+++ b/blog_engine/app/controllers/blog_engine/articles_controller.rb
@@ -21,7 +21,7 @@ module BlogEngine
     def create
       @article = Article.new(title: params[:title], body: params[:body])
       if @article.save
-        redirect_to @article, notice: 'Article was successfully created.'
+        render action: :show, json: @article
       else
         render :new
       end

--- a/blog_engine/app/controllers/blog_engine/articles_controller.rb
+++ b/blog_engine/app/controllers/blog_engine/articles_controller.rb
@@ -23,7 +23,7 @@ module BlogEngine
       if @article.save
         render action: :show, json: @article
       else
-        render :new
+        render json: { title: nil, body: nil }
       end
     end
 

--- a/blog_engine/app/views/blog_engine/articles/index.html.erb
+++ b/blog_engine/app/views/blog_engine/articles/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div id="articles-view" class="container">
   <p id="notice"><%= notice %></p>
   <h1>Listing Articles</h1>
   <table id="articles-list" class="table table-responsive">
@@ -20,7 +20,7 @@
     </tbody>
   </table>
 
-  <div id="article-form">
+  <div>
     <button @click="show=!show" class="btn btn-info">NewArticle</button>
     <div v-cloak>
       <div v-show="show">

--- a/blog_engine/app/views/blog_engine/articles/show.json.jbuilder
+++ b/blog_engine/app/views/blog_engine/articles/show.json.jbuilder
@@ -1,0 +1,5 @@
+json.article do
+  json.id @article[:id]
+  json.title @article[:title]
+  json.body @article[:body]
+end


### PR DESCRIPTION
## このPRについて
記事の新規作成後、ページを再読み込みすることなく一覧に反映されるように実装する。
関連Issueは #179 

（PR #178マージ後、rebaseします）

## WIPが外れる条件
- [x] Vue.jsのインスタンスがフォームと記事一覧で分かれているものを、親divにエレメントを設定してまとめる。
- [x] 通信部分が冗長なので別クラス化する
- [x] 記事が登録されたら一覧の中身も更新されるようにする

## 実装した画面
![github](https://user-images.githubusercontent.com/12405287/29259995-d18a5178-8101-11e7-8ffc-181c5c117811.gif)

